### PR TITLE
Increase resolution via pixel shifting in main camera 

### DIFF
--- a/src/cameras/drivers/model8374.cpp
+++ b/src/cameras/drivers/model8374.cpp
@@ -289,11 +289,31 @@ namespace camera8374_driver
                               sensor_msgs::ImagePtr &left_image)
   {
     bool success = true;
+    sensor_msgs::ImagePtr temp_right_image();
+    sensor_msgs::ImagePtr temp_left_image();
+
     try
       {
         // Read data from the Camera
         ROS_DEBUG_STREAM("[" << camera_name_ << "] reading data");
-        dev_->readData(*left_image, *right_image);
+        dev_->readData(temp_left_image, temp_right_image);
+        composite_data(temp_left_image, *left_image, temp_right_image, *right_image);
+
+        dev_->shiftCCD(RIGHT, 1);
+        dev_->readData(temp_left_image, temp_right_image);
+        composite_data(temp_left_image, *left_image, temp_right_image, *right_image);
+
+        dev_->shiftCCD(DOWN, 1);
+        dev_->readData(temp_left_image, temp_right_image);
+        composite_data(temp_left_image, *left_image, temp_right_image, *right_image);
+
+        dev_->shiftCCD(LEFT, 1);
+        dev_->readData(temp_left_image, temp_right_image);
+        composite_data(temp_left_image, *left_image, temp_right_image, *right_image);
+
+        // Return to the initial position
+        dev_->shiftCCD(UP, 1);
+
         ROS_DEBUG_STREAM("[" << camera_name_ << "] read returned");
       }
     catch (camera8374::Exception& e)

--- a/src/cameras/drivers/modes.cpp
+++ b/src/cameras/drivers/modes.cpp
@@ -75,6 +75,10 @@ namespace Modes
       "1600x1200_mono8",
       "1280x960_mono16",
       "1600x1200_mono16",
+      "2048x1536_rgb8"
+      "2048x1536_yuv422"
+      "2048x1536_mono8"
+      "2048x1536_mono16"
       "exif",
       "format7_mode0",
       "format7_mode1",


### PR DESCRIPTION
Use a technique known as [pixel-shifting](http://www.vision-systems.com/articles/print/volume-10/issue-5/technology-trends/ccd-sensors/pixel-shifting-increases-microscopy-resolution.html) to increase resolution of the main camera.
